### PR TITLE
missing ; added in CSS style

### DIFF
--- a/08/no-parallax.html
+++ b/08/no-parallax.html
@@ -7,7 +7,7 @@
 		<style>
 			*, html {
 				margin:0;
-				padding:0
+				padding:0;
 			}
 			#sky {
 				background:url('images/bg1.png') 50% 0;

--- a/08/parallax-result.html
+++ b/08/parallax-result.html
@@ -7,7 +7,7 @@
 		<style>
 			*, html {
 				margin:0;
-				padding:0
+				padding:0;
 			}
 			#sky {
 				background:url('images/bg1.png') 50% 0;

--- a/08/parallax.html
+++ b/08/parallax.html
@@ -7,7 +7,7 @@
 		<style>
 			*, html {
 				margin:0;
-				padding:0
+				padding:0;
 			}
 			#sky {
 				background:url('images/bg1.png') 50% 0;


### PR DESCRIPTION
CSS 마지막 속성 뒤에는 세미콜론(;)을 붙이지 않아도 상관없는 것을 알지만,
다른 예제 소스코드를 보아도 CSS 마지막 속성 끝에 항상 세미콜론(;)이 붙어있는걸 보니 일관성을 위해 여기에도 세미콜론(;)을 붙이는게 좋아보입니다.